### PR TITLE
FaceID bugfix + DigiID cancellation handler added

### DIFF
--- a/breadwallet.xcodeproj/project.pbxproj
+++ b/breadwallet.xcodeproj/project.pbxproj
@@ -1559,7 +1559,7 @@
 		CE4B6C1B1E21A96D00CF935B /* LoadingProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoadingProgressView.swift; path = src/Views/LoadingProgressView.swift; sourceTree = "<group>"; };
 		CE4B6C1F1E233C2C00CF935B /* UITableView+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UITableView+Additions.swift"; path = "src/Extensions/UITableView+Additions.swift"; sourceTree = "<group>"; };
 		CE4C1CC51ED65D830063E184 /* DrawableCircle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DrawableCircle.swift; path = src/Views/DrawableCircle.swift; sourceTree = "<group>"; };
-		CE4C1CC71ED88B600063E184 /* URLController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLController.swift; path = src/FlowControllers/URLController.swift; sourceTree = "<group>"; };
+		CE4C1CC71ED88B600063E184 /* URLController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLController.swift; sourceTree = "<group>"; };
 		CE4CA7B91EE0C8D900373F11 /* BitIdTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BitIdTests.swift; sourceTree = "<group>"; };
 		CE4CA7BB1EE3649100373F11 /* BRActivityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BRActivityView.swift; path = src/Platform/BRActivityView.swift; sourceTree = "<group>"; };
 		CE4DFB2B1E9BE5880014009E /* ReScanViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReScanViewController.swift; path = src/ViewControllers/ReScanViewController.swift; sourceTree = "<group>"; };
@@ -2730,10 +2730,10 @@
 				CE45C1FC1E7650F5002C3847 /* KVStoreCoordinator.swift */,
 				CEC6F8441E886723000795B8 /* PaymentRequest.swift */,
 				7528D2971ECF655500925DBC /* PaymentProtocol.swift */,
-				CE4C1CC71ED88B600063E184 /* URLController.swift */,
 				789FAE03208151E2003AF958 /* DigiIDRequest.swift */,
 				CE916E321EDA800E00D641D6 /* UserDefaultsUpdater.swift */,
 				CE3D4C561EF5D5740016B1C8 /* ReachabilityMonitor.swift */,
+				CE4C1CC71ED88B600063E184 /* URLController.swift */,
 				CE473D7B1F042F1E00C0ACFD /* coinflip.aiff */,
 				CE2990171EFD6DAF0093A0F2 /* Strings */,
 				CE30F0E41EB27821004B8EE5 /* Watch */,

--- a/breadwallet/Info.plist
+++ b/breadwallet/Info.plist
@@ -183,5 +183,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Wallet Authentication</string>
 </dict>
 </plist>

--- a/breadwallet/URLController.swift
+++ b/breadwallet/URLController.swift
@@ -122,7 +122,7 @@ class URLController : Trackable {
                     var r = 1
                     
                     if let origin = req?.originURL {
-                        // /* TESTING: */ if let origin = Optional("https://digiid.digibyteprojects.com/login") {
+                    // /* TESTING: */ if let origin = Optional("https://digiid.digibyteprojects.com/login") {
                         var url = ""
                         switch(senderApp) {
                             case "com.apple.mobilesafari":
@@ -156,8 +156,16 @@ class URLController : Trackable {
                         self.present(alert: alert)
                     }
                 } else {
-                    // Something went wrong, we'll display an alert 
-                    let alert = UIAlertController(title: S.BitID.error, message: S.BitID.errorMessage, preferredStyle: .alert)
+                    // Something went wrong, we'll display an alert
+                    var additionalInformation: String {
+                        if let resp = response as? HTTPURLResponse {
+                            return "\(resp.statusCode)"
+                        }
+                        
+                        return ""
+                    }
+                    
+                    let alert = UIAlertController(title: S.BitID.error, message: "\(S.BitID.errorMessage).\n\nStatus: \(additionalInformation)", preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: S.Button.ok, style: .default, handler: nil))
                     self.present(alert: alert)
                 }

--- a/breadwallet/src/Platform/BRDigiID.swift
+++ b/breadwallet/src/Platform/BRDigiID.swift
@@ -108,8 +108,10 @@ open class BRDigiID : NSObject {
             return
         }
         let prompt = url.host ?? url.description
-        store.trigger(name: .authenticateForBitId(prompt, {_ in
-            self.run(completionHandler)
+        store.trigger(name: .authenticateForBitId(prompt, { (s) -> Void in
+            if case .success = s {
+                self.run(completionHandler)
+            }
         }))
     }
 


### PR DESCRIPTION
- Fixed the FaceID crash that occurred on devices running iOS 11.3.
- Although hitting cancel on TouchID/FaceID authrequest, the resource was requested nevertheless. This bad security issue is fixed now